### PR TITLE
Enhanced the makefile for local dev work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,12 @@ endif
 
 # Dev Server
 start:
+	poetry run uvicorn app.main:app --reload --port $(PORT)
+
+start-server:
 	docker compose -f docker-compose.support.yml up -d
+	QUEUE_MODE = remote
+	STORAGE_MODE = mongo
 	poetry run uvicorn app.main:app --reload --port $(PORT)
 
 stop:

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,11 @@ endif
 
 # Dev Server
 start:
+	docker compose -f docker-compose.support.yml up -d
 	poetry run uvicorn app.main:app --reload --port $(PORT)
+
+stop:
+	docker compose -f docker-compose.support.yml down
 
 # Docker
 docker-build:
@@ -108,7 +112,7 @@ docker-run:
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up --build
 
 docker-dev:
-	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.dev.yml up --build
+	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.support.yml -f docker-compose.dev.yml up --build
 
 docker-postman-test:
 	@echo 🧪 RUNNING POSTMAN TESTS IN DOCKER

--- a/app/api/v1/mediator/ballot.py
+++ b/app/api/v1/mediator/ballot.py
@@ -191,7 +191,7 @@ def save_ballot_queue(casted_ballot: Any) -> Any:
 
 def save_ballot_db(casted_ballot: Any) -> Any:
     ballot = CiphertextBallot.from_json_object(json.loads(casted_ballot))
-    uri = os.environ.get("MONGODB_URI", "mongodb://root:example@mongo:27017")
+    uri = os.environ.get("MONGODB_URI", "mongodb://root:example@localhost:27017")
     client = MongoClient(uri)
     database = client.get_database("BallotData")
     collection = database.get_collection("SubmittedBallots")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,16 +4,6 @@
 
 version: "3.8"
 services:
-  messagequeue:
-    image: rabbitmq:3.8.16-management-alpine
-    container_name: 'electionguard-message-queue'
-    expose: 
-      - 5672
-      - 15672
-    ports:
-      - 5672:5672
-      - 15672:15672
-
   mediator:
     build:
       context: .
@@ -27,7 +17,7 @@ services:
       PROJECT_NAME: "ElectionGuard Mediator API"
       PORT: 8000
       MESSAGEQUEUE_URI: "amqp://guest:guest@electionguard-message-queue:5672"
-      MONGODB_URI: "mongodb://root:example@mongo:27017"
+      MONGODB_URI: "mongodb://root:example@electionguard-db:27017"
 
   guardian:
     build:
@@ -41,28 +31,3 @@ services:
       API_MODE: "guardian"
       PROJECT_NAME: "ElectionGuard Guardian API"
       PORT: 8001
-
-  mongo:
-    image: mongo
-    container_name: 'electionguard-db'
-    restart: always
-    ports:
-      - 27017:27017
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: example
-      MONGO_INITDB_DATABASE: BallotData
-    volumes: 
-      - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
-
-  mongo-express:
-    image: mongo-express
-    restart: always
-    ports:
-      - 8081:8081
-    environment:
-      ME_CONFIG_MONGODB_ADMINUSERNAME: root
-      ME_CONFIG_MONGODB_ADMINPASSWORD: example   
-    links:
-      - 'mongo'
-

--- a/docker-compose.support.yml
+++ b/docker-compose.support.yml
@@ -1,0 +1,40 @@
+# This hosts both APIs locally in parallel
+# It mounts the codebase within the container and runs the APIs
+# with hot reload enabled.
+
+version: "3.8"
+services:
+  messagequeue:
+    image: rabbitmq:3.8.16-management-alpine
+    container_name: 'electionguard-message-queue'
+    expose: 
+      - 5672
+      - 15672
+    ports:
+      - 5672:5672
+      - 15672:15672
+
+  mongo:
+    image: mongo
+    container_name: 'electionguard-db'
+    restart: always
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+      MONGO_INITDB_DATABASE: BallotData
+    volumes: 
+      - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: example   
+    links:
+      - 'mongo'
+


### PR DESCRIPTION
### Description
Some developers use `make docker-dev` to do development work while other use `make start` instead.  This change enhances the makefile and adds an additional docker-compose file to support the extra servers being run locally.

### Changes
Added new docker-compose for the support docker images (messagequeue, mongo, mongoexpress).  
Enhanced makefile start to use the new file.  
Added makefile stop command to shut down the docker images
Fixed default for mongo uri

### Testing
1. `make start` should see the rabbitmq, mongo and mongexpress docker images download and run using `docker ps`
2.  `make stop` should shut down the support docker images
