### PR TITLE
Azure deploy from Github Actions

### DIFF
--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -49,7 +49,7 @@ jobs:
               {
                 "name": "electionguard-api-python-guardian",
                 "image": "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
-                "environmentVariables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\"",
+                "environmentVariables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672 MONGODB_URI2=${{ secrets.COSMOSDB_URI }}\"",
                 "secureEnvironmentVariables": "MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
                 "cpu": 1,
                 "memory": 1,

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -36,7 +36,7 @@ jobs:
             registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
             registry-username: ${{ secrets.REGISTRY_USERNAME }}
             registry-password: ${{ secrets.REGISTRY_PASSWORD }}
-            name: electionguard-api-python
+            name: electionguard-api-python-mediator
             environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue:5672"
             secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }}
             location: 'east us'
@@ -48,7 +48,7 @@ jobs:
             resource-group: ${{ secrets.RESOURCE_GROUP }}
             dns-name-label: electionguard-message-queue
             image: rabbitmq:3.8.16-management-alpine
-            name: electionguard-api-python
+            name: electionguard-message-queue
             location: 'east us'
             ports: 5672 15672
 

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -42,6 +42,8 @@ jobs:
                 image: "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
                 environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672",
                 secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
+                "cpu": 1,
+                "memory": 1,
                 ports: "8000"
               }, 
               {
@@ -49,11 +51,15 @@ jobs:
                 image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }},
                 environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672",
                 secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
+                "cpu": 1,
+                "memory": 1,
                 ports: "8001"
               }, 
               {
                 name: electionguard-message-queue,
                 image: rabbitmq:3.8.16-management-alpine,
+                "cpu": 1,
+                "memory": 1,
                 ports: "5672 15672"
               }]'
 #

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -38,23 +38,23 @@ jobs:
             location: 'east us'
             containers: '[
               { 
-                name: electionguard-api-python-mediator,
-                image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }},
+                name: "electionguard-api-python-mediator",
+                image: "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
                 environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672",
                 secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
-                ports: 8000
+                ports: "8000"
               }, 
               {
                 name: electionguard-api-python-guardian,
                 image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }},
                 environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672",
                 secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
-                ports: 8001
+                ports: "8001"
               }, 
               {
                 name: electionguard-message-queue,
                 image: rabbitmq:3.8.16-management-alpine,
-                ports: 5672 15672
+                ports: "5672 15672"
               }]'
 #
 #        - name: 'Deploy Mediator to Azure Container Instances'

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -37,7 +37,7 @@ jobs:
             registry-username: ${{ secrets.REGISTRY_USERNAME }}
             registry-password: ${{ secrets.REGISTRY_PASSWORD }}
             name: electionguard-api-python-mediator
-            environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue:5672"
+            environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672"
             secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }}
             location: 'east us'
             ports: 8000

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -1,14 +1,18 @@
-name: Azure_Deply_Workflow
+name: Azure_Deploy_Workflow
 on: 
   push:
     branches:
       - azure-deploy
+  milestone:
+    types: [closed]
+  repository_dispatch:
+    types: [milestone_closed]
 
 jobs:
     build-and-deploy:
         runs-on: ubuntu-latest
         steps:
-        # checkout the repo
+
         - name: 'Checkout GitHub Action'
           uses: actions/checkout@main
           
@@ -24,8 +28,8 @@ jobs:
             username: ${{ secrets.REGISTRY_USERNAME }}
             password: ${{ secrets.REGISTRY_PASSWORD }}
         - run: |
-            docker build . -t ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
-            docker push ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
+            docker build . -t ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }} -t ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:latest
+            docker push ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python --all-tags
 
         - name: 'Deploy All to Azure Container Instances'
           uses: 'pierreVH2/azure-containergroup-deploy@master'
@@ -38,65 +42,25 @@ jobs:
             location: 'east us'
             containers: '[
               { 
-                name: "electionguard-api-python-mediator",
-                image: "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
-                "environmentVariables": "API_MODE=mediator QUEUE_MODE=remote STORAGE_MODE=mongo PROJECT_NAME=ElectionGuard_Mediator_API PORT=8000 MESSAGEQUEUE_URI=amqp://guest:guest@electionguard-message-queue:5672 MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
+                "name": "electionguard-api-python-mediator",
+                "image": "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:latest",
+                "environmentVariables": "API_MODE=\"mediator\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Mediator API\" PORT=8000 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\" MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
                 "cpu": 1,
                 "memory": 1,
-                ports: "8000"
+                "ports": "8000"
               }, 
               {
                 "name": "electionguard-api-python-guardian",
-                "image": "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
-                "environmentVariables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\" MONGODB_URI=\"${{ secrets.COSMOSDB_URI }}\"",
+                "image": "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:latest",
+                "environmentVariables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\" MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
                 "cpu": 1,
                 "memory": 1,
-                ports: "8001"
+                "ports": "8001"
               }, 
               {
-                name: electionguard-message-queue,
-                image: rabbitmq:3.8.16-management-alpine,
+                "name": "electionguard-message-queue",
+                "image": "rabbitmq:3.8.16-management-alpine",
                 "cpu": 1,
                 "memory": 1,
-                ports: "5672 15672"
+                "ports": "5672 15672"
               }]'
-#
-#        - name: 'Deploy Mediator to Azure Container Instances'
-        #   uses: 'azure/aci-deploy@v1'
-        #   with:
-        #     resource-group: ${{ secrets.RESOURCE_GROUP }}
-        #     dns-name-label: electionguard-api-python-mediator
-        #     image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
-        #     registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        #     registry-username: ${{ secrets.REGISTRY_USERNAME }}
-        #     registry-password: ${{ secrets.REGISTRY_PASSWORD }}
-        #     name: electionguard-api-python-mediator
-        #     environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672"
-        #     secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }}
-        #     location: 'east us'
-        #     ports: 8000
-
-        # - name: 'Deploy Guardian to Azure Container Instances'
-        #   uses: 'azure/aci-deploy@v1'
-        #   with:
-        #     resource-group: ${{ secrets.RESOURCE_GROUP }}
-        #     dns-name-label: electionguard-api-python-guardian
-        #     image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
-        #     registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        #     registry-username: ${{ secrets.REGISTRY_USERNAME }}
-        #     registry-password: ${{ secrets.REGISTRY_PASSWORD }}
-        #     name: electionguard-api-python-guardian
-        #     environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 
-        #     location: 'east us'
-        #     ports: 8001
-
-        # - name: 'Deploy MessageQueue to Azure Container Instances'
-        #   uses: 'azure/aci-deploy@v1'
-        #   with:
-        #     resource-group: ${{ secrets.RESOURCE_GROUP }}
-        #     dns-name-label: electionguard-message-queue
-        #     image: rabbitmq:3.8.16-management-alpine
-        #     name: electionguard-message-queue
-        #     location: 'east us'
-        #     ports: 5672 15672
-

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -16,6 +16,13 @@ jobs:
           uses: azure/login@v1
           with:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+        - name: 'Build and push image'
+          uses: azure/docker-login@v1
+          with:
+            login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+            username: ${{ secrets.REGISTRY_USERNAME }}
+            password: ${{ secrets.REGISTRY_PASSWORD }}
         - run: |
             docker build . -t ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
             docker push ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -27,3 +27,28 @@ jobs:
             docker build . -t ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
             docker push ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
 
+        - name: 'Deploy Mediator to Azure Container Instances'
+          uses: 'azure/aci-deploy@v1'
+          with:
+            resource-group: ${{ secrets.RESOURCE_GROUP }}
+            dns-name-label: ${{ secrets.RESOURCE_GROUP }}${{ github.run_number }}
+            image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
+            registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+            registry-username: ${{ secrets.REGISTRY_USERNAME }}
+            registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+            name: electionguard-api-python
+            environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue:5672"
+            secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }}
+            location: 'east us'
+            ports: 8000
+
+        - name: 'Deploy MessageQueue to Azure Container Instances'
+          uses: 'azure/aci-deploy@v1'
+          with:
+            resource-group: ${{ secrets.RESOURCE_GROUP }}
+            dns-name-label: electionguard-message-queue
+            image: rabbitmq:3.8.16-management-alpine
+            name: electionguard-api-python
+            location: 'east us'
+            ports: 5672 15672
+

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -40,8 +40,8 @@ jobs:
               { 
                 name: "electionguard-api-python-mediator",
                 image: "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
-                "environment-variables": "API_MODE=mediator QUEUE_MODE=remote STORAGE_MODE=mongo PROJECT_NAME=ElectionGuard_Mediator_API PORT=8000 MESSAGEQUEUE_URI=amqp://guest:guest@electionguard-message-queue:5672",
-                "secure-environment-variables": "MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
+                "environmentVariables": "API_MODE=mediator QUEUE_MODE=remote STORAGE_MODE=mongo PROJECT_NAME=ElectionGuard_Mediator_API PORT=8000 MESSAGEQUEUE_URI=amqp://guest:guest@electionguard-message-queue:5672",
+                "secureEnvironmentVariables": "MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
                 "cpu": 1,
                 "memory": 1,
                 ports: "8000"
@@ -49,8 +49,8 @@ jobs:
               {
                 "name": "electionguard-api-python-guardian",
                 "image": "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
-                "environment-variables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\"",
-                "secure-environment-variables": "MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
+                "environmentVariables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\"",
+                "secureEnvironmentVariables": "MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
                 "cpu": 1,
                 "memory": 1,
                 ports: "8001"

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -40,17 +40,17 @@ jobs:
               { 
                 name: "electionguard-api-python-mediator",
                 image: "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
-                environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue:5672",
-                secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
+                "environment-variables": "API_MODE=mediator QUEUE_MODE=remote STORAGE_MODE=mongo PROJECT_NAME=ElectionGuard_Mediator_API PORT=8000 MESSAGEQUEUE_URI=amqp://guest:guest@electionguard-message-queue:5672",
+                "secure-environment-variables": "MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
                 "cpu": 1,
                 "memory": 1,
                 ports: "8000"
               }, 
               {
-                name: electionguard-api-python-guardian,
-                image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }},
-                environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue:5672",
-                secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
+                "name": "electionguard-api-python-guardian",
+                "image": "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
+                "environment-variables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\"",
+                "secure-environment-variables": "MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
                 "cpu": 1,
                 "memory": 1,
                 ports: "8001"

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -40,8 +40,7 @@ jobs:
               { 
                 name: "electionguard-api-python-mediator",
                 image: "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
-                "environmentVariables": "API_MODE=mediator QUEUE_MODE=remote STORAGE_MODE=mongo PROJECT_NAME=ElectionGuard_Mediator_API PORT=8000 MESSAGEQUEUE_URI=amqp://guest:guest@electionguard-message-queue:5672",
-                "secureEnvironmentVariables": "MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
+                "environmentVariables": "API_MODE=mediator QUEUE_MODE=remote STORAGE_MODE=mongo PROJECT_NAME=ElectionGuard_Mediator_API PORT=8000 MESSAGEQUEUE_URI=amqp://guest:guest@electionguard-message-queue:5672 MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
                 "cpu": 1,
                 "memory": 1,
                 ports: "8000"
@@ -49,8 +48,7 @@ jobs:
               {
                 "name": "electionguard-api-python-guardian",
                 "image": "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
-                "environmentVariables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672 MONGODB_URI2=${{ secrets.COSMOSDB_URI }}\"",
-                "secureEnvironmentVariables": "MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
+                "environmentVariables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\" MONGODB_URI=\"${{ secrets.COSMOSDB_URI }}\"",
                 "cpu": 1,
                 "memory": 1,
                 ports: "8001"

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -2,7 +2,7 @@ name: Azure_Deploy_Workflow
 on: 
   push:
     branches:
-      - azure-deploy
+      - main
   milestone:
     types: [closed]
   repository_dispatch:
@@ -45,22 +45,22 @@ jobs:
                 "name": "electionguard-api-python-mediator",
                 "image": "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:latest",
                 "environmentVariables": "API_MODE=\"mediator\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Mediator API\" PORT=8000 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\" MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
-                "cpu": 1,
-                "memory": 1,
+                "cpu": 2,
+                "memory": 2,
                 "ports": "8000"
               }, 
               {
                 "name": "electionguard-api-python-guardian",
                 "image": "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:latest",
                 "environmentVariables": "API_MODE=\"guardian\" QUEUE_MODE=\"remote\" STORAGE_MODE=\"mongo\" PROJECT_NAME=\"ElectionGuard Guardian API\" PORT=8001 MESSAGEQUEUE_URI=\"amqp://guest:guest@electionguard-message-queue:5672\" MONGODB_URI=${{ secrets.COSMOSDB_URI }}",
-                "cpu": 1,
-                "memory": 1,
+                "cpu": 2,
+                "memory": 2,
                 "ports": "8001"
               }, 
               {
                 "name": "electionguard-message-queue",
                 "image": "rabbitmq:3.8.16-management-alpine",
-                "cpu": 1,
-                "memory": 1,
+                "cpu": 2,
+                "memory": 4,
                 "ports": "5672 15672"
               }]'

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -27,42 +27,72 @@ jobs:
             docker build . -t ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
             docker push ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
 
-        - name: 'Deploy Mediator to Azure Container Instances'
-          uses: 'azure/aci-deploy@v1'
+        - name: 'Deploy All to Azure Container Instances'
+          uses: 'pierreVH2/azure-containergroup-deploy@master'
           with:
             resource-group: ${{ secrets.RESOURCE_GROUP }}
-            dns-name-label: electionguard-api-python-mediator
-            image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
+            group-name: electionguard-api-python
             registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
             registry-username: ${{ secrets.REGISTRY_USERNAME }}
             registry-password: ${{ secrets.REGISTRY_PASSWORD }}
-            name: electionguard-api-python-mediator
-            environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672"
-            secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }}
             location: 'east us'
-            ports: 8000
+            containers: '[
+              { 
+                name: electionguard-api-python-mediator,
+                image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }},
+                environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672",
+                secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
+                ports: 8000
+              }, 
+              {
+                name: electionguard-api-python-guardian,
+                image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }},
+                environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672",
+                secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
+                ports: 8001
+              }, 
+              {
+                name: electionguard-message-queue,
+                image: rabbitmq:3.8.16-management-alpine,
+                ports: 5672 15672
+              }]'
+#
+#        - name: 'Deploy Mediator to Azure Container Instances'
+        #   uses: 'azure/aci-deploy@v1'
+        #   with:
+        #     resource-group: ${{ secrets.RESOURCE_GROUP }}
+        #     dns-name-label: electionguard-api-python-mediator
+        #     image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
+        #     registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+        #     registry-username: ${{ secrets.REGISTRY_USERNAME }}
+        #     registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+        #     name: electionguard-api-python-mediator
+        #     environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672"
+        #     secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }}
+        #     location: 'east us'
+        #     ports: 8000
 
-        - name: 'Deploy Guardian to Azure Container Instances'
-          uses: 'azure/aci-deploy@v1'
-          with:
-            resource-group: ${{ secrets.RESOURCE_GROUP }}
-            dns-name-label: electionguard-api-python-guardian
-            image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
-            registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-            registry-username: ${{ secrets.REGISTRY_USERNAME }}
-            registry-password: ${{ secrets.REGISTRY_PASSWORD }}
-            name: electionguard-api-python-guardian
-            environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 
-            location: 'east us'
-            ports: 8001
+        # - name: 'Deploy Guardian to Azure Container Instances'
+        #   uses: 'azure/aci-deploy@v1'
+        #   with:
+        #     resource-group: ${{ secrets.RESOURCE_GROUP }}
+        #     dns-name-label: electionguard-api-python-guardian
+        #     image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
+        #     registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+        #     registry-username: ${{ secrets.REGISTRY_USERNAME }}
+        #     registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+        #     name: electionguard-api-python-guardian
+        #     environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 
+        #     location: 'east us'
+        #     ports: 8001
 
-        - name: 'Deploy MessageQueue to Azure Container Instances'
-          uses: 'azure/aci-deploy@v1'
-          with:
-            resource-group: ${{ secrets.RESOURCE_GROUP }}
-            dns-name-label: electionguard-message-queue
-            image: rabbitmq:3.8.16-management-alpine
-            name: electionguard-message-queue
-            location: 'east us'
-            ports: 5672 15672
+        # - name: 'Deploy MessageQueue to Azure Container Instances'
+        #   uses: 'azure/aci-deploy@v1'
+        #   with:
+        #     resource-group: ${{ secrets.RESOURCE_GROUP }}
+        #     dns-name-label: electionguard-message-queue
+        #     image: rabbitmq:3.8.16-management-alpine
+        #     name: electionguard-message-queue
+        #     location: 'east us'
+        #     ports: 5672 15672
 

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -40,7 +40,7 @@ jobs:
               { 
                 name: "electionguard-api-python-mediator",
                 image: "${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}",
-                environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672",
+                environment-variables: API_MODE="mediator" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Mediator API" PORT=8000 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue:5672",
                 secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
                 "cpu": 1,
                 "memory": 1,
@@ -49,7 +49,7 @@ jobs:
               {
                 name: electionguard-api-python-guardian,
                 image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }},
-                environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue.eastus.azurecontainer.io:5672",
+                environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 MESSAGEQUEUE_URI="amqp://guest:guest@electionguard-message-queue:5672",
                 secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }},
                 "cpu": 1,
                 "memory": 1,

--- a/.github/workflows/azure_deploy.yml
+++ b/.github/workflows/azure_deploy.yml
@@ -31,7 +31,7 @@ jobs:
           uses: 'azure/aci-deploy@v1'
           with:
             resource-group: ${{ secrets.RESOURCE_GROUP }}
-            dns-name-label: ${{ secrets.RESOURCE_GROUP }}${{ github.run_number }}
+            dns-name-label: electionguard-api-python-mediator
             image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
             registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
             registry-username: ${{ secrets.REGISTRY_USERNAME }}
@@ -41,6 +41,20 @@ jobs:
             secure-environment-variables: MONGODB_URI=${{ secrets.COSMOSDB_URI }}
             location: 'east us'
             ports: 8000
+
+        - name: 'Deploy Guardian to Azure Container Instances'
+          uses: 'azure/aci-deploy@v1'
+          with:
+            resource-group: ${{ secrets.RESOURCE_GROUP }}
+            dns-name-label: electionguard-api-python-guardian
+            image: ${{ secrets.DEPLOY_REGISTRY }}.azurecr.io/electionguard-api-python:${{ github.sha }}
+            registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+            registry-username: ${{ secrets.REGISTRY_USERNAME }}
+            registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+            name: electionguard-api-python-guardian
+            environment-variables: API_MODE="guardian" QUEUE_MODE="remote" STORAGE_MODE="mongo" PROJECT_NAME="ElectionGuard Guardian API" PORT=8001 
+            location: 'east us'
+            ports: 8001
 
         - name: 'Deploy MessageQueue to Azure Container Instances'
           uses: 'azure/aci-deploy@v1'


### PR DESCRIPTION
### Description
Integrate Github Action with pushing the images up to Azure.  Setup an instance of the mediator, guardian, and Message Queue that can be used.  Tie these images to also use a CosmosDb in MongoDb mode to be the back end database.

### Testing
When a PR is merged into main or a release is closed, the containers up in azure demo site should be updated.  
