### PR TITLE
Add Election API's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: environment lint start
 environment:
 	@echo 🔧 SETUP
 	make install-gmp
-	pip install 'poetry==1.1.6'
+	pip3 install 'poetry==1.1.6'
 	poetry config virtualenvs.in-project true 
 	poetry install
 

--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -1,14 +1,70 @@
-from typing import Any
+from typing import Any, List, Optional
+from enum import Enum
 
-from .base import BaseRequest
+from .base import Base, BaseRequest, BaseResponse
 from .manifest import ElectionManifest
 
 
 __all__ = [
+    "Election",
+    "ElectionState",
+    "ElectionQueryRequest",
+    "ElectionQueryResponse",
     "MakeElectionContextRequest",
+    "MakeElectionContextResponse",
+    "SubmitElectionRequest",
+    "SubmitElectionResponse",
 ]
 
 CiphertextElectionContext = Any
+
+
+class ElectionState(str, Enum):
+    CREATED = "CREATED"
+    OPEN = "OPEN"
+    CLOSED = "CLOSED"
+    PUBLISHED = "PUBLISHED"
+
+
+class Election(Base):
+    """An election object"""
+
+    election_id: str
+    state: ElectionState
+    context: CiphertextElectionContext
+    manifest: ElectionManifest
+
+
+class ElectionQueryRequest(BaseRequest):
+    """A request for elections using the specified filter"""
+
+    filter: Optional[Any] = None
+    """
+    a json object filter that will be applied to the search
+    """
+
+    class Config:
+        schema_extra = {"example": {"filter": {"election_id": "some-election-id-123"}}}
+
+
+class ElectionQueryResponse(BaseResponse):
+    """A collection of elections"""
+
+    elections: List[Election]
+
+
+class SubmitElectionRequest(BaseRequest):
+    """Submit an election"""
+
+    election_id: Optional[str] = None
+    context: CiphertextElectionContext
+    manifest: Optional[ElectionManifest] = None
+
+
+class SubmitElectionResponse(BaseResponse):
+    """A submitted election id"""
+
+    election_id: str
 
 
 class MakeElectionContextRequest(BaseRequest):
@@ -16,8 +72,15 @@ class MakeElectionContextRequest(BaseRequest):
     A request to build an Election Context for a given election
     """
 
-    manifest: ElectionManifest
     elgamal_public_key: str
     commitment_hash: str
     number_of_guardians: int
     quorum: int
+    description_hash: Optional[str] = None  # TODO: rename to manifest_hash
+    manifest: Optional[ElectionManifest] = None
+
+
+class MakeElectionContextResponse(BaseResponse):
+    """A Ciphertext Election Context"""
+
+    context: CiphertextElectionContext

--- a/app/api/v1/models/manifest.py
+++ b/app/api/v1/models/manifest.py
@@ -1,8 +1,19 @@
-from typing import Any
+from typing import Any, List, Optional
 
-from .base import BaseResponse, BaseValidationRequest
+from .base import (
+    BaseRequest,
+    BaseResponse,
+    BaseValidationRequest,
+    BaseValidationResponse,
+)
 
-__all__ = ["ManifestSubmitResponse", "ManifestQueryResponse", "ValidateManifestRequest"]
+__all__ = [
+    "ManifestSubmitResponse",
+    "ManifestQueryRequest",
+    "ManifestQueryResponse",
+    "ValidateManifestRequest",
+    "ValidateManifestResponse",
+]
 
 ElectionManifest = Any
 ElementModQ = Any
@@ -12,8 +23,14 @@ class ManifestSubmitResponse(BaseResponse):
     manifest_hash: ElementModQ
 
 
+class ManifestQueryRequest(BaseRequest):
+    """A request for manifests using the specified filter"""
+
+    filter: Optional[Any] = None
+
+
 class ManifestQueryResponse(BaseResponse):
-    manifest: ElectionManifest
+    manifests: List[ElectionManifest]
 
 
 class ValidateManifestRequest(BaseValidationRequest):
@@ -23,3 +40,7 @@ class ValidateManifestRequest(BaseValidationRequest):
 
     manifest: ElectionManifest
     """The manifest to validate"""
+
+
+class ValidateManifestResponse(BaseValidationResponse):
+    manifest_hash: Optional[str] = None

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1,5 +1,5 @@
-MANIFEST = "Election Manifest"
 ELECTION = "Configure Election"
+MANIFEST = "Election Manifest"
 KEY_CEREMONY = "Key Ceremony"
 BALLOTS = "Query Ballots"
 ENCRYPT = "Encrypt Ballots"

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,9 @@ def get_app(settings: Optional[Settings] = None) -> FastAPI:
         settings = Settings()
 
     web_app = FastAPI(
-        title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/openapi.json"
+        title=settings.PROJECT_NAME,
+        openapi_url=f"{settings.API_V1_STR}/openapi.json",
+        version="1.0.5",
     )
 
     logger.error(f"Starting API in {settings.API_MODE} mode")

--- a/tests/integration/mediator_api.py
+++ b/tests/integration/mediator_api.py
@@ -18,7 +18,43 @@ def combine_election_keys(election_public_keys: List[Dict]) -> Dict:
     return api_utils.send_post_request(_api_client, "key/election/combine", request)
 
 
-def create_election_context(
+def get_election(election_id: str) -> Dict:
+    return api_utils.send_get_request(
+        _api_client, f"election?election_id={election_id}"
+    )
+
+
+def submit_election(
+    election_id: str,
+    context: Dict,
+    manifest: Dict,
+) -> Dict:
+    """
+    Construct an encryption context for use throughout the election to encrypt and decrypt data
+    """
+    request = {"election_id": election_id, "context": context, "manifest": manifest}
+    return api_utils.send_put_request(_api_client, "election", request)
+
+
+def open_election(election_id: str) -> Dict:
+    return api_utils.send_post_request(
+        _api_client, f"election/open?election_id={election_id}"
+    )
+
+
+def close_election(election_id: str) -> Dict:
+    return api_utils.send_post_request(
+        _api_client, f"election/close?election_id={election_id}"
+    )
+
+
+def publish_election(election_id: str) -> Dict:
+    return api_utils.send_post_request(
+        _api_client, f"election/publish?election_id={election_id}"
+    )
+
+
+def build_election_context(
     manifest: Dict,
     elgamal_public_key: str,
     commitment_hash: str,

--- a/tests/integration/test_end_to_end_election.py
+++ b/tests/integration/test_end_to_end_election.py
@@ -48,7 +48,7 @@ def prepare_election(description: Dict) -> Tuple[List[Dict], Dict]:
 
     commitment_hash = "2"
 
-    context = mediator_api.create_election_context(
+    context = mediator_api.build_election_context(
         description, elgamal_public_key, commitment_hash, NUMBER_OF_GUARDIANS, QUORUM
     )
 


### PR DESCRIPTION
### Issue
*Link your PR to an issue*

Fixes #145

### Description
Add the election API's to manage election state.  The most interesting addition is the ability to call `/find` using a json body with an arbitrary query parameter that will filter results based on the object.

### Testing
1. fire up docker and postman
2. call build election context
3. call submit election
4. call get election
5. call find elections
6. call open election
7. call find elections

validate they all return results

