### PR TITLE
Upgrade dockerfile to python3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8 AS base
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9 AS base
 ENV PORT 8000
 RUN apt update && apt-get install -y \
     libgmp-dev \


### PR DESCRIPTION
### Issue

Fixes #182

### Description
Upgrades the dockerfile to python 3.9

### Testing
1. `make docker-run`
2. Hit http://localhost:8000/docs

It should produce swagger ui