### PR TITLE
🐛 Fix error "Protocols cannot be instantiated"

### DIFF
--- a/app/core/repository.py
+++ b/app/core/repository.py
@@ -1,4 +1,4 @@
-from typing import Dict, Protocol, Any, List, Union
+from typing import Dict, Any, List, Union
 from collections.abc import MutableMapping
 from abc import ABC
 

--- a/app/core/repository.py
+++ b/app/core/repository.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any, List, Union
 from collections.abc import MutableMapping
-from abc import ABC
+from abc import ABC, abstractmethod
 
 import mmap
 import os
@@ -33,21 +33,25 @@ class IRepository(ABC):
     def __exit__(self, exc_type: Any, exc_value: Any, exc_traceback: Any) -> None:
         pass
 
+    @abstractmethod
     def find(self, filter: MutableMapping, skip: int = 0, limit: int = 0) -> Any:
         """
         Find items matching the filter
         """
 
+    @abstractmethod
     def get(self, filter: MutableMapping) -> Any:
         """
         Get an item from the container
         """
 
+    @abstractmethod
     def set(self, value: DOCUMENT_VALUE_TYPE) -> Any:
         """
         Set and item in the container
         """
 
+    @abstractmethod
     def update(self, filter: MutableMapping, value: DOCUMENT_VALUE_TYPE) -> Any:
         """
         Update an item

--- a/app/core/repository.py
+++ b/app/core/repository.py
@@ -1,5 +1,6 @@
 from typing import Dict, Protocol, Any, List, Union
 from collections.abc import MutableMapping
+from abc import ABC
 
 import mmap
 import os
@@ -25,7 +26,7 @@ __all__ = [
 DOCUMENT_VALUE_TYPE = Union[MutableMapping, List[MutableMapping]]
 
 
-class IRepository(Protocol):
+class IRepository(ABC):
     def __enter__(self) -> Any:
         return self
 


### PR DESCRIPTION
### Issue
Fixes #188 

### Description
Currently if you hit just about any endpoint e.g. PUT /guardian it fails and in the console prints an error like (<class 'TypeError'>, TypeError('Protocols cannot be instantiated'), <traceback object at 0x7f4b02e8f200>).  This PR fixes it by converting IRepository from an interface to an abstract base class.

### Testing
1. `make docker-dev`
2. `PUT /guardian`

It should succeed