### PR TITLE
🐛 docker-postman-test now works on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ stop:
 
 # Docker
 docker-build:
-	DOCKER_BUILDKIT=1 docker build -t $(IMAGE_NAME) .
+	docker build -t $(IMAGE_NAME) .
 
 docker-run:
 	docker-compose up --build
@@ -112,9 +112,9 @@ docker-run:
 docker-dev:
 	docker-compose -f docker-compose.support.yml -f docker-compose.dev.yml up --build
 
-docker-postman-test: no-windows
+docker-postman-test:
 	@echo 🧪 RUNNING POSTMAN TESTS IN DOCKER
-	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose \
+	docker-compose \
 	-f tests/postman/docker-compose.yml up \
 	--build \
 	--abort-on-container-exit \


### PR DESCRIPTION
### Issue

Fixes #187 

### Description

docker-postman-test didn't previously run on Windows because of the unnecessary `no-windows` recipe prerequisite and the setting of variables that aren't necessary anyway.

### Testing

On Windows run `make docker-postman-test`