### PR TITLE
Nswag

### DIFF
--- a/app/api/v1/auth/auth.py
+++ b/app/api/v1/auth/auth.py
@@ -14,6 +14,7 @@ from fastapi import (
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import JWTError, jwt
 from pydantic import ValidationError
+from app.api.v1.models.auth import ErrorMessage
 
 from app.api.v1.models.user import UserScope
 from app.core import Settings
@@ -124,7 +125,12 @@ def validate_access_token(
     return token_data
 
 
-@router.post("/login", response_model=Token, tags=[AUTHORIZE])
+@router.post(
+    "/login",
+    response_model=Token,
+    tags=[AUTHORIZE],
+    responses={401: {"model": ErrorMessage}, 404: {"model": ErrorMessage}},
+)
 async def login_for_access_token(
     request: Request, form_data: OAuth2PasswordRequestForm = Depends()
 ) -> Token:

--- a/app/api/v1/models/auth.py
+++ b/app/api/v1/models/auth.py
@@ -30,3 +30,9 @@ class TokenData(BaseModel):
 
     username: Optional[str] = None
     scopes: List[UserScope] = []
+
+
+class ErrorMessage(BaseModel):
+    """Returns error messages to the client."""
+
+    detail: str

--- a/app/api/v1_1/routes.py
+++ b/app/api/v1_1/routes.py
@@ -9,8 +9,6 @@ from . import guardian
 def get_v1_1_routes(settings: Settings) -> APIRouter:
     api_router = APIRouter()
 
-    api_router.include_router(auth.router)
-
     if settings.API_MODE == ApiMode.GUARDIAN:
         api_router.include_router(guardian.router)
     elif settings.API_MODE == ApiMode.MEDIATOR:

--- a/app/core/election.py
+++ b/app/core/election.py
@@ -1,3 +1,4 @@
+import traceback
 from typing import Any, List
 
 import sys
@@ -44,7 +45,7 @@ def get_election(election_id: str, settings: Settings = Settings()) -> Election:
 
             return election
     except Exception as error:
-        print(sys.exc_info())
+        traceback.print_exc()
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"{election_id} not found",
@@ -61,7 +62,7 @@ def set_election(election: Election, settings: Settings = Settings()) -> BaseRes
                 message="Election Successfully Set",
             )
     except Exception as error:
-        print(sys.exc_info())
+        traceback.print_exc()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Submit election failed",
@@ -81,7 +82,7 @@ def filter_elections(
                 elections.append(election_from_query(item))
             return elections
     except Exception as error:
-        print(sys.exc_info())
+        traceback.print_exc()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="find elections failed",
@@ -106,7 +107,7 @@ def update_election_state(
             repository.update({"election_id": election_id}, election.dict())
             return BaseResponse()
     except Exception as error:
-        print(sys.exc_info())
+        traceback.print_exc()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="update election failed",

--- a/app/core/election.py
+++ b/app/core/election.py
@@ -1,7 +1,6 @@
 import traceback
 from typing import Any, List
 
-import sys
 from fastapi import HTTPException, status
 
 from electionguard.serializable import write_json_object

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -38,8 +38,8 @@ class Settings(BaseSettings):
         default=[
             "http://localhost",
             "http://localhost:8080",
-            "http://localhost:6006",
-            "http://localhost:3000",
+            "http://localhost:3001",
+            "http://localhost:3002",
             "https://localhost",
         ]
     )

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
     STORAGE_MODE: StorageMode = StorageMode.LOCAL_STORAGE
 
     API_V1_STR: str = "/api/v1"
-    API_V1_1_STR: str = "/api/v1.1"
+    API_V1_1_STR: str = "/api/v1_1"
     BACKEND_CORS_ORIGINS: List[AnyHttpUrl] = Field(
         default=[
             "http://localhost",


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue

Fixes #196 

### Description

- `1.1` in the URL causes a problem for code generators, so replaces that with `1_1`
- Documents the 404 and 401 HTTP responses for the login method in swagger
- Excludes the duplicate login endpoints in 1.1
- Fixes CORS to match the UI
- Better logging of errors for election endpoints

### Testing
This primarily is in support of [#108 ](https://github.com/microsoft/electionguard-ui/issues/108), so if you can run that this PR is good.