### PR TITLE
Context serialization

### DIFF
--- a/app/api/v1/mediator/election.py
+++ b/app/api/v1/mediator/election.py
@@ -9,7 +9,6 @@ from electionguard.election import (
     make_ciphertext_election_context,
 )
 from electionguard.group import ElementModP, ElementModQ
-from electionguard.election import CiphertextElectionContext
 from electionguard.manifest import Manifest
 from electionguard.serializable import read_json_object, write_json_object
 from electionguard.utils import get_optional
@@ -76,7 +75,7 @@ def create_election(
         election_id = str(uuid4())
 
     key_ceremony = get_key_ceremony(data.key_name, request.app.state.settings)
-    context = CiphertextElectionContext.from_json_object(data.context)
+    context = data.context.toSdkContext()
 
     # if a manifest is provided use it, but don't cache it
     if data.manifest:

--- a/app/api/v1/models/ballot.py
+++ b/app/api/v1/models/ballot.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from .base import Base, BaseRequest, BaseResponse, BaseValidationRequest
-from .election import CiphertextElectionContext
+from .election import CiphertextElectionContextDto
 from .manifest import ElectionManifest
 
 
@@ -60,7 +60,7 @@ class BallotQueryResponse(BaseResponse):
 class BaseBallotRequest(BaseRequest):
     election_id: Optional[str] = None
     manifest: Optional[ElectionManifest] = None
-    context: Optional[CiphertextElectionContext] = None
+    context: Optional[CiphertextElectionContextDto] = None
 
 
 class CastBallotsRequest(BaseBallotRequest):
@@ -86,4 +86,4 @@ class ValidateBallotRequest(BaseValidationRequest):
 
     ballot: CiphertextBallot
     manifest: ElectionManifest
-    context: CiphertextElectionContext
+    context: CiphertextElectionContextDto

--- a/app/api/v1/models/decrypt.py
+++ b/app/api/v1/models/decrypt.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List
 
 from .base import BaseRequest
-from .election import CiphertextElectionContext
+from .election import CiphertextElectionContextDto
 from .guardian import Guardian, GuardianId
 
 __all__ = [
@@ -21,13 +21,13 @@ class DecryptBallotsWithSharesRequest(BaseRequest):
 
     encrypted_ballots: List[SubmittedBallot]
     shares: Dict[GuardianId, List[DecryptionShare]]
-    context: CiphertextElectionContext
+    context: CiphertextElectionContextDto
 
 
 class DecryptBallotSharesRequest(BaseRequest):
     encrypted_ballots: List[SubmittedBallot]
     guardian: Guardian
-    context: CiphertextElectionContext
+    context: CiphertextElectionContextDto
 
 
 class DecryptBallotSharesResponse(BaseRequest):

--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -52,32 +52,34 @@ class CiphertextElectionContextDto(Base):
     """The `extended base hash code (𝑄')` in [ElectionGuard Spec](https://github.com/microsoft/electionguard/wiki)"""
 
     @staticmethod
-    def hexToP(s: str) -> ElementModP:
-        v = hex_to_p(s)
-        if v is None:
+    def stringToElementModP(s: str) -> ElementModP:
+        elementModP = hex_to_p(s)
+        if elementModP is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail="invalid key"
             )
-        return v
+        return elementModP
 
     @staticmethod
-    def hexToQ(s: str) -> ElementModQ:
-        v = hex_to_q(s)
-        if v is None:
+    def stringToElementModQ(s: str) -> ElementModQ:
+        elementModQ = hex_to_q(s)
+        if elementModQ is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail="invalid key"
             )
-        return v
+        return elementModQ
 
     def toSdkContext(self) -> CiphertextElectionContext:
         sdkContext = CiphertextElectionContext(
             self.number_of_guardians,
             self.quorum,
-            CiphertextElectionContextDto.hexToP(self.elgamal_public_key),
-            CiphertextElectionContextDto.hexToQ(self.commitment_hash),
-            CiphertextElectionContextDto.hexToQ(self.manifest_hash),
-            CiphertextElectionContextDto.hexToQ(self.crypto_base_hash),
-            CiphertextElectionContextDto.hexToQ(self.crypto_extended_base_hash),
+            CiphertextElectionContextDto.stringToElementModP(self.elgamal_public_key),
+            CiphertextElectionContextDto.stringToElementModQ(self.commitment_hash),
+            CiphertextElectionContextDto.stringToElementModQ(self.manifest_hash),
+            CiphertextElectionContextDto.stringToElementModQ(self.crypto_base_hash),
+            CiphertextElectionContextDto.stringToElementModQ(
+                self.crypto_extended_base_hash
+            ),
         )
         return sdkContext
 

--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -52,8 +52,8 @@ class CiphertextElectionContextDto(Base):
     """The `extended base hash code (𝑄')` in [ElectionGuard Spec](https://github.com/microsoft/electionguard/wiki)"""
 
     @staticmethod
-    def stringToElementModP(s: str) -> ElementModP:
-        elementModP = hex_to_p(s)
+    def stringToElementModP(value: str) -> ElementModP:
+        elementModP = hex_to_p(value)
         if elementModP is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail="invalid key"
@@ -61,11 +61,11 @@ class CiphertextElectionContextDto(Base):
         return elementModP
 
     @staticmethod
-    def stringToElementModQ(s: str) -> ElementModQ:
-        elementModQ = hex_to_q(s)
+    def stringToElementModQ(value: str) -> ElementModQ:
+        elementModQ = hex_to_q(value)
         if elementModQ is None:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="invalid key"
+                status_code=status.HTTP_400_BAD_REQUEST, detail="invalid key: " + value
             )
         return elementModQ
 

--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 
-class CiphertextElectionContext(Base):
+class CiphertextElectionContextDto(Base):
     """The meta-data required for an election including keys, manifest, number of guardians, and quorum"""
 
     number_of_guardians: int
@@ -60,7 +60,7 @@ class Election(Base):
     election_id: str
     key_name: str
     state: ElectionState
-    context: CiphertextElectionContext
+    context: CiphertextElectionContextDto
     manifest: ElectionManifest
 
 
@@ -87,7 +87,7 @@ class SubmitElectionRequest(BaseRequest):
 
     election_id: str
     key_name: str
-    context: CiphertextElectionContext
+    context: CiphertextElectionContextDto
     manifest: Optional[ElectionManifest] = None
 
 
@@ -107,4 +107,4 @@ class MakeElectionContextRequest(BaseRequest):
 class MakeElectionContextResponse(BaseResponse):
     """A Ciphertext Election Context."""
 
-    context: CiphertextElectionContext
+    context: CiphertextElectionContextDto

--- a/app/api/v1/models/tally_decrypt.py
+++ b/app/api/v1/models/tally_decrypt.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 from electionguard.types import BALLOT_ID
 
 from .base import BaseResponse, BaseRequest, Base
-from .election import CiphertextElectionContext
+from .election import CiphertextElectionContextDto
 from .tally import CiphertextTally
 
 __all__ = [
@@ -38,7 +38,7 @@ class DecryptTallyShareRequest(BaseRequest):
 
     guardian_id: str
     encrypted_tally: CiphertextTally
-    context: CiphertextElectionContext
+    context: CiphertextElectionContextDto
 
 
 class DecryptionShareRequest(BaseRequest):


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue

Fixes #200 

### Description
Fixes serialization of context when PUT'ing to /election

### Testing
1. PUT to `{{mediator-url}}/api/{{version}}/election` with a context

Expected: it should work now like this:

![image](https://user-images.githubusercontent.com/1769905/152190926-b68cef35-566b-4673-a11f-a2a760dd8ec1.png)

If you use an invalid key, it should give a halfway decent error message like this:

![image](https://user-images.githubusercontent.com/1769905/152190855-dd485c31-b587-4ebc-8f64-a82566bd4353.png)
