### PR TITLE
🗳️ list elections with ballots

### DIFF
--- a/app/api/v1/mediator/election.py
+++ b/app/api/v1/mediator/election.py
@@ -132,7 +132,7 @@ def to_election_summary(election: Election):
     dto = ElectionSummaryDto(
         election_id=election.election_id,
         name=election.get_name(),
-        state=str(election.state),
+        state=election.state,
         number_of_guardians=election.context.number_of_guardians,
         quorum=election.context.quorum,
         cast_ballots=0,

--- a/app/api/v1/mediator/election.py
+++ b/app/api/v1/mediator/election.py
@@ -137,6 +137,7 @@ def to_election_summary(election: Election):
         quorum=election.context.quorum,
         cast_ballots=0,
         spoiled_ballots=0,
+        index=0,
     )
     return dto
 
@@ -155,15 +156,19 @@ def list_elections(
     """
 
     result = ElectionListResponseDto()
-    elections = filter_elections({}, 0, 1000, request.app.state.settings)
+    elections = filter_elections(filter={}, settings=request.app.state.settings)
     result.elections = [to_election_summary(e) for e in elections]
+    index = 0
     for election in result.elections:
+        election.index = index
         inventory = get_ballot_inventory(
             election.election_id, request.app.state.settings
         )
         if inventory is not None:
             election.cast_ballots = inventory.cast_ballot_count
             election.spoiled_ballots = inventory.spoiled_ballot_count
+        index = index + 1
+    result.elections.sort(key=lambda e: e.index, reverse=True)
 
     return result
 

--- a/app/api/v1/mediator/election.py
+++ b/app/api/v1/mediator/election.py
@@ -131,6 +131,7 @@ def create_election(
 def to_election_summary(election: Election):
     dto = ElectionSummaryDto(
         election_id=election.election_id,
+        name=election.get_name(),
         state=str(election.state),
         number_of_guardians=election.context.number_of_guardians,
         quorum=election.context.quorum,
@@ -155,7 +156,7 @@ def list_elections(
 
     result = ElectionListResponseDto()
     elections = filter_elections({}, 0, 1000, request.app.state.settings)
-    result.elections = list(map(to_election_summary, elections))
+    result.elections = [to_election_summary(e) for e in elections]
     for election in result.elections:
         inventory = get_ballot_inventory(
             election.election_id, request.app.state.settings

--- a/app/api/v1/mediator/election.py
+++ b/app/api/v1/mediator/election.py
@@ -12,8 +12,10 @@ from electionguard.group import ElementModP, ElementModQ
 from electionguard.manifest import Manifest
 from electionguard.serializable import read_json_object, write_json_object
 from electionguard.utils import get_optional
+from app.api.v1.auth.auth import ScopedTo
 
 from app.api.v1.models.election import ElectionListResponseDto, ElectionSummaryDto
+from app.api.v1.models.user import UserScope
 
 from .manifest import get_manifest
 from ....core.ballot import get_ballot_inventory, upsert_ballot_inventory
@@ -40,7 +42,7 @@ from ..tags import ELECTION
 router = APIRouter()
 
 
-@router.get("/constants", tags=[ELECTION])
+@router.get("/constants", dependencies=[ScopedTo([UserScope.admin])], tags=[ELECTION])
 def get_election_constants() -> Any:
     """
     Get the constants defined for an election.
@@ -49,7 +51,12 @@ def get_election_constants() -> Any:
     return constants.to_json_object()
 
 
-@router.get("", response_model=ElectionQueryResponse, tags=[ELECTION])
+@router.get(
+    "",
+    response_model=ElectionQueryResponse,
+    dependencies=[ScopedTo([UserScope.admin])],
+    tags=[ELECTION],
+)
 def fetch_election(request: Request, election_id: str) -> ElectionQueryResponse:
     """Get an election by election id."""
     election = get_election(election_id, request.app.state.settings)
@@ -58,7 +65,12 @@ def fetch_election(request: Request, election_id: str) -> ElectionQueryResponse:
     )
 
 
-@router.put("", response_model=BaseResponse, tags=[ELECTION])
+@router.put(
+    "",
+    response_model=BaseResponse,
+    dependencies=[ScopedTo([UserScope.admin])],
+    tags=[ELECTION],
+)
 def create_election(
     request: Request,
     data: SubmitElectionRequest = Body(...),
@@ -128,7 +140,12 @@ def to_election_summary(election: Election):
     return dto
 
 
-@router.post("/list", response_model=ElectionListResponseDto, tags=[ELECTION])
+@router.post(
+    "/list",
+    response_model=ElectionListResponseDto,
+    dependencies=[ScopedTo([UserScope.admin])],
+    tags=[ELECTION],
+)
 def list_elections(
     request: Request,
 ) -> ElectionListResponseDto:
@@ -150,7 +167,12 @@ def list_elections(
     return result
 
 
-@router.post("/find", response_model=ElectionQueryResponse, tags=[ELECTION])
+@router.post(
+    "/find",
+    response_model=ElectionQueryResponse,
+    dependencies=[ScopedTo([UserScope.admin])],
+    tags=[ELECTION],
+)
 def find_elections(
     request: Request,
     skip: int = 0,
@@ -168,7 +190,12 @@ def find_elections(
     return ElectionQueryResponse(elections=elections)
 
 
-@router.post("/open", response_model=BaseResponse, tags=[ELECTION])
+@router.post(
+    "/open",
+    response_model=BaseResponse,
+    dependencies=[ScopedTo([UserScope.admin])],
+    tags=[ELECTION],
+)
 def open_election(request: Request, election_id: str) -> BaseResponse:
     """
     Open an election.
@@ -182,7 +209,12 @@ def open_election(request: Request, election_id: str) -> BaseResponse:
     )
 
 
-@router.post("/close", response_model=BaseResponse, tags=[ELECTION])
+@router.post(
+    "/close",
+    response_model=BaseResponse,
+    dependencies=[ScopedTo([UserScope.admin])],
+    tags=[ELECTION],
+)
 def close_election(request: Request, election_id: str) -> BaseResponse:
     """
     Close an election.
@@ -192,7 +224,12 @@ def close_election(request: Request, election_id: str) -> BaseResponse:
     )
 
 
-@router.post("/publish", response_model=BaseResponse, tags=[ELECTION])
+@router.post(
+    "/publish",
+    response_model=BaseResponse,
+    dependencies=[ScopedTo([UserScope.admin])],
+    tags=[ELECTION],
+)
 def publish_election(request: Request, election_id: str) -> BaseResponse:
     """
     Publish an election.
@@ -202,7 +239,12 @@ def publish_election(request: Request, election_id: str) -> BaseResponse:
     )
 
 
-@router.post("/context", response_model=MakeElectionContextResponse, tags=[ELECTION])
+@router.post(
+    "/context",
+    response_model=MakeElectionContextResponse,
+    dependencies=[ScopedTo([UserScope.admin])],
+    tags=[ELECTION],
+)
 def build_election_context(
     request: Request,
     data: MakeElectionContextRequest = Body(...),

--- a/app/api/v1/mediator/election.py
+++ b/app/api/v1/mediator/election.py
@@ -247,7 +247,6 @@ def publish_election(request: Request, election_id: str) -> BaseResponse:
 @router.post(
     "/context",
     response_model=MakeElectionContextResponse,
-    dependencies=[ScopedTo([UserScope.admin])],
     tags=[ELECTION],
 )
 def build_election_context(

--- a/app/api/v1/mediator/election.py
+++ b/app/api/v1/mediator/election.py
@@ -135,8 +135,8 @@ def to_election_summary(election: Election) -> ElectionSummaryDto:
         state=election.state,
         number_of_guardians=election.context.number_of_guardians,
         quorum=election.context.quorum,
-        cast_ballots=0,
-        spoiled_ballots=0,
+        cast_ballot_count=0,
+        spoiled_ballot_count=0,
         index=0,
     )
 
@@ -164,8 +164,8 @@ def list_elections(
             election.election_id, request.app.state.settings
         )
         if inventory is not None:
-            election.cast_ballots = inventory.cast_ballot_count
-            election.spoiled_ballots = inventory.spoiled_ballot_count
+            election.cast_ballot_count = inventory.cast_ballot_count
+            election.spoiled_ballot_count = inventory.spoiled_ballot_count
         index = index + 1
     result.elections.sort(key=lambda e: e.index, reverse=True)
 

--- a/app/api/v1/mediator/election.py
+++ b/app/api/v1/mediator/election.py
@@ -128,8 +128,8 @@ def create_election(
     return set_election(election, request.app.state.settings)
 
 
-def to_election_summary(election: Election):
-    dto = ElectionSummaryDto(
+def to_election_summary(election: Election) -> ElectionSummaryDto:
+    return ElectionSummaryDto(
         election_id=election.election_id,
         name=election.get_name(),
         state=election.state,
@@ -139,7 +139,6 @@ def to_election_summary(election: Election):
         spoiled_ballots=0,
         index=0,
     )
-    return dto
 
 
 @router.post(

--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -79,7 +79,7 @@ class Election(Base):
         text = self.manifest["name"]["text"]
         # todo: replace "en" with user's current culture
         enText = [t["value"] for t in text if t["language"] == "en"]
-        return enText[0]
+        return str(enText[0])
 
     election_id: str
     key_name: str

--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -75,6 +75,12 @@ class ElectionState(str, Enum):
 class Election(Base):
     """An election object."""
 
+    def get_name(self) -> str:
+        text = self.manifest["name"]["text"]
+        # todo: replace "en" with user's current culture
+        enText = [t["value"] for t in text if t["language"] == "en"]
+        return enText[0]
+
     election_id: str
     key_name: str
     state: ElectionState
@@ -102,6 +108,7 @@ class ElectionQueryResponse(BaseResponse):
 
 class ElectionSummaryDto(Base):
     election_id: str
+    name: Any
     state: str
     number_of_guardians: int
     quorum: int

--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -114,6 +114,7 @@ class ElectionSummaryDto(Base):
     quorum: int
     cast_ballots: int
     spoiled_ballots: int
+    index: int
 
 
 class ElectionListResponseDto(BaseResponse):

--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -100,6 +100,21 @@ class ElectionQueryResponse(BaseResponse):
     elections: List[Election] = []
 
 
+class ElectionSummaryDto(Base):
+    election_id: str
+    state: str
+    number_of_guardians: int
+    quorum: int
+    cast_ballots: int
+    spoiled_ballots: int
+
+
+class ElectionListResponseDto(BaseResponse):
+    """A collection of elections."""
+
+    elections: List[ElectionSummaryDto] = []
+
+
 class SubmitElectionRequest(BaseRequest):
     """Submit an election."""
 

--- a/app/api/v1/models/election.py
+++ b/app/api/v1/models/election.py
@@ -112,8 +112,8 @@ class ElectionSummaryDto(Base):
     state: str
     number_of_guardians: int
     quorum: int
-    cast_ballots: int
-    spoiled_ballots: int
+    cast_ballot_count: int
+    spoiled_ballot_count: int
     index: int
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from app.core.scheduler import get_scheduler
 
 
-@pytest.yield_fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def scheduler_lifespan() -> Generator[None, None, None]:
     """
     Ensure that the global scheduler singleton is


### PR DESCRIPTION
### Issue
Fixes #176 
Fixes #202 

### Description
Adds a new endpoint for retrieving elections along with their name and the number of ballots they contain (both spoiled and cast).  Results sorted reverse chronologically.

### Testing

1. Authenticate
2. Hit {{mediator-url}}/api/{{version}}/election/list

Expected: a list of elections like:

```
{
    "status": "success",
    "message": null,
    "elections": [
        {
            "election_id": "hamilton-general-election-simple",
            "name": "Hamiltion County General Election",
            "state": "OPEN",
            "number_of_guardians": 5,
            "quorum": 3,
            "cast_ballots": 7,
            "spoiled_ballots": 2
        }
    ]
}
```