### PR TITLE
Removed old port number from settings

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -39,7 +39,6 @@ class Settings(BaseSettings):
             "http://localhost",
             "http://localhost:8080",
             "http://localhost:3001",
-            "http://localhost:3002",
             "https://localhost",
         ]
     )


### PR DESCRIPTION
### Issue
*Link your PR to an issue*

Fixes #199 

### Description
Removed port 3002 from the settings.  This has been changed and is not needed.

### Testing
