### PR TITLE
📫 #221 Postman Collection Tests for Election Ceremony

### DIFF
--- a/tests/postman/ElectionGuard API Tests.postman_collection.json
+++ b/tests/postman/ElectionGuard API Tests.postman_collection.json
@@ -33,12 +33,12 @@
 									"urlencoded": [
 										{
 											"key": "username",
-											"value": "default",
+											"value": "{{admin-username}}",
 											"type": "text"
 										},
 										{
 											"key": "password",
-											"value": "<this is a default value and should be changed>",
+											"value": "{{admin-password}}",
 											"type": "text"
 										},
 										{

--- a/tests/postman/ElectionGuard API Tests.postman_collection.json
+++ b/tests/postman/ElectionGuard API Tests.postman_collection.json
@@ -18,8 +18,12 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"var jsonData = pm.response.json();",
-											"pm.environment.set(\"token\", jsonData.access_token);"
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    var jsonData = pm.response.json();",
+											"    pm.environment.set(\"token\", jsonData.access_token);",
+											"});",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -90,7 +94,21 @@
 									"listen": "prerequest",
 									"script": {
 										"exec": [
-											"pm.collectionVariables.set(\"run-id\", Math.floor(Math.random() * 10000).toString());"
+											"const runId = Math.floor(Math.random() * 100000);\r",
+											"pm.collectionVariables.set(\"run-id\", runId.toString());\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -133,6 +151,18 @@
 										],
 										"type": "text/javascript"
 									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
 								}
 							],
 							"request": {
@@ -168,6 +198,20 @@
 					"item": [
 						{
 							"name": "3.1 Create Key Ceremony",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "PUT",
 								"header": [],
@@ -197,6 +241,20 @@
 						},
 						{
 							"name": "3.2 Create Mediator Guardian1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "PUT",
 								"header": [],
@@ -225,6 +283,20 @@
 						},
 						{
 							"name": "3.3 Create Mediator Guardian2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "PUT",
 								"header": [],
@@ -253,6 +325,20 @@
 						},
 						{
 							"name": "3.4 Create Guardian1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -282,6 +368,20 @@
 						},
 						{
 							"name": "3.5 Create Guardian2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -316,9 +416,14 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"var jsonData = pm.response.json();\r",
-											"pm.collectionVariables.set(\"user1-public-key-value\", jsonData.public_keys.election.key);\r",
-											"pm.collectionVariables.set(\"user1-public-key-all\", JSON.stringify(jsonData.public_keys));"
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.collectionVariables.set(\"user1-public-key-value\", jsonData.public_keys.election.key);\r",
+											"    pm.collectionVariables.set(\"user1-public-key-all\", JSON.stringify(jsonData.public_keys));\r",
+											"});\r",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -355,9 +460,14 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"var jsonData = pm.response.json();\r",
-											"pm.collectionVariables.set(\"user2-public-key-value\", jsonData.public_keys.election.key);\r",
-											"pm.collectionVariables.set(\"user2-public-key-all\", JSON.stringify(jsonData.public_keys));"
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.collectionVariables.set(\"user2-public-key-value\", jsonData.public_keys.election.key);\r",
+											"    pm.collectionVariables.set(\"user2-public-key-all\", JSON.stringify(jsonData.public_keys));\r",
+											"});\r",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -389,6 +499,20 @@
 						},
 						{
 							"name": "3.8 Open Key Ceremony",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -421,6 +545,9 @@
 									"listen": "test",
 									"script": {
 										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
 											""
 										],
 										"type": "text/javascript"
@@ -462,6 +589,9 @@
 									"listen": "test",
 									"script": {
 										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
 											""
 										],
 										"type": "text/javascript"
@@ -503,10 +633,15 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"var jsonData = pm.response.json();\r",
-											"pm.collectionVariables.set(\"user1-backups\", JSON.stringify(jsonData.backups));\r",
-											"pm.collectionVariables.set(\"user1-backup1-value\", jsonData.backups[0].encrypted_value);\r",
-											"pm.collectionVariables.set(\"user1-backup2-value\", jsonData.backups[1].encrypted_value);"
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.collectionVariables.set(\"user1-backups\", JSON.stringify(jsonData.backups));\r",
+											"    pm.collectionVariables.set(\"user1-backup1-value\", jsonData.backups[0].encrypted_value);\r",
+											"    pm.collectionVariables.set(\"user1-backup2-value\", jsonData.backups[1].encrypted_value);    \r",
+											"});\r",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -546,10 +681,15 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"var jsonData = pm.response.json();\r",
-											"pm.collectionVariables.set(\"user2-backups\", JSON.stringify(jsonData.backups));\r",
-											"pm.collectionVariables.set(\"user2-backup1-value\", jsonData.backups[0].encrypted_value);\r",
-											"pm.collectionVariables.set(\"user2-backup2-value\", jsonData.backups[1].encrypted_value);"
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.collectionVariables.set(\"user2-backups\", JSON.stringify(jsonData.backups));\r",
+											"    pm.collectionVariables.set(\"user2-backup1-value\", jsonData.backups[0].encrypted_value);\r",
+											"    pm.collectionVariables.set(\"user2-backup2-value\", jsonData.backups[1].encrypted_value);    \r",
+											"});\r",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -584,6 +724,20 @@
 						},
 						{
 							"name": "3.13 Share Guardian1 Backups",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -614,6 +768,20 @@
 						},
 						{
 							"name": "3.14 Share Guardian2 Backups",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -644,6 +812,20 @@
 						},
 						{
 							"name": "3.15 Verify Guardian1 Backup (Guardian)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -674,6 +856,20 @@
 						},
 						{
 							"name": "3.16 Verify Guardian2 Backup (Guardian)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -704,6 +900,20 @@
 						},
 						{
 							"name": "3.17 Verify Guardian1 Backups (Mediator)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -734,6 +944,20 @@
 						},
 						{
 							"name": "3.18 Verify Guardian2 Backups (Mediator)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -769,9 +993,23 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"var jsonData = pm.response.json();\r",
-											"pm.collectionVariables.set(\"elgamal_public_key\", jsonData.elgamal_public_key);\r",
-											"pm.collectionVariables.set(\"commitment_hash\", jsonData.commitment_hash);"
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Elgamal Public Key is defined\", function() {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    var elgamalPublicKey = jsonData.elgamal_public_key;\r",
+											"    pm.expect(elgamalPublicKey).not.eq(undefined);\r",
+											"\r",
+											"    pm.collectionVariables.set(\"elgamal_public_key\", elgamalPublicKey);\r",
+											"    pm.collectionVariables.set(\"commitment_hash\", jsonData.commitment_hash);\r",
+											"});\r",
+											"\r",
+											"// print key ceremony name to test results (since it contains the run id, everything else can be inferred)\r",
+											"const keyName = 'e2e-key_ceremony_' + pm.variables.get('run-id');\r",
+											"tests[keyName] = keyName;\r",
+											""
 										],
 										"type": "text/javascript"
 									}

--- a/tests/postman/ElectionGuard API Tests.postman_collection.json
+++ b/tests/postman/ElectionGuard API Tests.postman_collection.json
@@ -81,10 +81,10 @@
 					]
 				},
 				{
-					"name": "2. Create User",
+					"name": "2. Create Users",
 					"item": [
 						{
-							"name": "2.1 Create Guardian",
+							"name": "2.1 Create User1",
 							"event": [
 								{
 									"listen": "prerequest",
@@ -101,7 +101,46 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"username\": \"e2e-{{run-id}}\",\n    \"first_name\": \"Ben-{{run-id}}\",\n    \"last_name\": \"Franklin-{{run-id}}\",\n    \"email\": \"ben.franklin.{{run-id}}@usa.gov\",\n    \"scopes\": [\n        \"guardian\"\n    ]\n}",
+									"raw": "{\n    \"username\": \"e2e-ada-{{run-id}}\",\n    \"first_name\": \"Ada\",\n    \"last_name\": \"Lovelace\",\n    \"email\": \"ada.lovelace.{{run-id}}@uk.gov\",\n    \"scopes\": [\n        \"guardian\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/user",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"user"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "2.1 Create User2",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"username\": \"e2e-alan-{{run-id}}\",\n    \"first_name\": \"Alan\",\n    \"last_name\": \"Turing\",\n    \"email\": \"alan.turing.{{run-id}}@uk.gov\",\n    \"scopes\": [\n        \"guardian\"\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -125,15 +164,101 @@
 					]
 				},
 				{
-					"name": "3. Create Joint Key",
-					"item": []
-				},
-				{
-					"name": "4. Key Ceremony",
-					"item": []
+					"name": "3. Key Ceremony",
+					"item": [
+						{
+							"name": "3.1 Create Key Ceremony",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key_name\": \"e2e-key_ceremony_{{run-id}}\",\n    \"number_of_guardians\": 2,\n    \"quorum\": 2,\n    \"guardian_ids\": [\n        \"e2e-ada-{{run-id}}\",\n        \"e2e-alan-{{run-id}}\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/key/ceremony",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"key",
+										"ceremony"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.2 Create Mediator Guardian1",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key_name\": \"e2e-key_ceremony_{{run-id}}\",\n    \"guardian_id\": \"e2e-ada-{{run-id}}\",\n    \"name\": \"Ada Lovelace\",\n    \"sequence_order\": 1,\n    \"number_of_guardians\": 2,\n    \"quorum\": 2\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/guardian",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.2 Create Mediator Guardian2",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key_name\": \"e2e-key_ceremony_{{run-id}}\",\n    \"guardian_id\": \"e2e-alan-{{run-id}}\",\n    \"name\": \"Alan Turing\",\n    \"sequence_order\": 2,\n    \"number_of_guardians\": 2,\n    \"quorum\": 2\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/guardian",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian"
+									]
+								}
+							},
+							"response": []
+						}
+					]
 				},
 				{
 					"name": "5. Election Setup",
+					"item": []
+				},
+				{
+					"name": "3. Create Joint Key",
 					"item": []
 				},
 				{

--- a/tests/postman/ElectionGuard API Tests.postman_collection.json
+++ b/tests/postman/ElectionGuard API Tests.postman_collection.json
@@ -1,0 +1,182 @@
+{
+	"info": {
+		"_postman_id": "6909f57a-7b81-4378-9548-140b6135d969",
+		"name": "ElectionGuard API Tests",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "End-To-End Happy Path",
+			"item": [
+				{
+					"name": "1. Authenticate",
+					"item": [
+						{
+							"name": "1.1 Login",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();",
+											"pm.environment.set(\"token\", jsonData.access_token);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "username",
+											"value": "default",
+											"type": "text"
+										},
+										{
+											"key": "password",
+											"value": "<this is a default value and should be changed>",
+											"type": "text"
+										},
+										{
+											"key": "grant_type",
+											"value": "password",
+											"type": "text"
+										},
+										{
+											"key": "scope",
+											"value": "admin",
+											"type": "text"
+										},
+										{
+											"key": "client_id",
+											"value": "electionguard-default-client-id",
+											"type": "text"
+										},
+										{
+											"key": "client_secret",
+											"value": "electionguard-default-client-secret",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/auth/login",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"auth",
+										"login"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "2. Create User",
+					"item": [
+						{
+							"name": "2.1 Create Guardian",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"run-id\", Math.floor(Math.random() * 10000).toString());"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"username\": \"e2e-{{run-id}}\",\n    \"first_name\": \"Ben-{{run-id}}\",\n    \"last_name\": \"Franklin-{{run-id}}\",\n    \"email\": \"ben.franklin.{{run-id}}@usa.gov\",\n    \"scopes\": [\n        \"guardian\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/user",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"user"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "3. Create Joint Key",
+					"item": []
+				},
+				{
+					"name": "4. Key Ceremony",
+					"item": []
+				},
+				{
+					"name": "5. Election Setup",
+					"item": []
+				},
+				{
+					"name": "New Folder",
+					"item": []
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{token}}",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "run-id",
+			"value": ""
+		}
+	]
+}

--- a/tests/postman/ElectionGuard API Tests.postman_collection.json
+++ b/tests/postman/ElectionGuard API Tests.postman_collection.json
@@ -224,7 +224,7 @@
 							"response": []
 						},
 						{
-							"name": "3.2 Create Mediator Guardian2",
+							"name": "3.3 Create Mediator Guardian2",
 							"request": {
 								"method": "PUT",
 								"header": [],
@@ -246,6 +246,566 @@
 										"api",
 										"{{version}}",
 										"guardian"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.4 Create Guardian1",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"guardian_id\": \"e2e-ada-{{run-id}}\",\n    \"name\": \"Ada Lovelace\",\n    \"sequence_order\": 1,\n    \"number_of_guardians\": 2,\n    \"quorum\": 2\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{guardian-url}}/api/{{version}}/guardian",
+									"host": [
+										"{{guardian-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian"
+									]
+								},
+								"description": "Start a tally by passing in a batch of ballots.  This will return a tally that can be passed back in to accumulate further ballots."
+							},
+							"response": []
+						},
+						{
+							"name": "3.5 Create Guardian2",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"guardian_id\": \"e2e-alan-{{run-id}}\",\n    \"name\": \"Alan Turing\",\n    \"sequence_order\": 2,\n    \"number_of_guardians\": 2,\n    \"quorum\": 2\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{guardian-url}}/api/{{version}}/guardian",
+									"host": [
+										"{{guardian-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian"
+									]
+								},
+								"description": "Start a tally by passing in a batch of ballots.  This will return a tally that can be passed back in to accumulate further ballots."
+							},
+							"response": []
+						},
+						{
+							"name": "3.6 Get Public Key1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();\r",
+											"pm.collectionVariables.set(\"user1-public-key-value\", jsonData.public_keys.election.key);\r",
+											"pm.collectionVariables.set(\"user1-public-key-all\", JSON.stringify(jsonData.public_keys));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{guardian-url}}/api/{{version}}/guardian/public-keys?guardian_id=e2e-ada-{{run-id}}",
+									"host": [
+										"{{guardian-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian",
+										"public-keys"
+									],
+									"query": [
+										{
+											"key": "guardian_id",
+											"value": "e2e-ada-{{run-id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.7 Get Public Key2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();\r",
+											"pm.collectionVariables.set(\"user2-public-key-value\", jsonData.public_keys.election.key);\r",
+											"pm.collectionVariables.set(\"user2-public-key-all\", JSON.stringify(jsonData.public_keys));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{guardian-url}}/api/{{version}}/guardian/public-keys?guardian_id=e2e-alan-{{run-id}}",
+									"host": [
+										"{{guardian-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian",
+										"public-keys"
+									],
+									"query": [
+										{
+											"key": "guardian_id",
+											"value": "e2e-alan-{{run-id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.8 Open Key Ceremony",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/key/ceremony/open?key_name=e2e-key_ceremony_{{run-id}}",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"key",
+										"ceremony",
+										"open"
+									],
+									"query": [
+										{
+											"key": "key_name",
+											"value": "e2e-key_ceremony_{{run-id}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.9 Announce Guardian1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key_name\": \"e2e-key_ceremony_{{run-id}}\",\n    \"public_keys\": {{user1-public-key-all}}\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/key/guardian/announce",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"key",
+										"guardian",
+										"announce"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.10 Announce Guardian2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key_name\": \"e2e-key_ceremony_{{run-id}}\",\n    \"public_keys\": {{user2-public-key-all}}\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/key/guardian/announce",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"key",
+										"guardian",
+										"announce"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.11 Create Guardian1 Backup",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();\r",
+											"pm.collectionVariables.set(\"user1-backups\", JSON.stringify(jsonData.backups));\r",
+											"pm.collectionVariables.set(\"user1-backup1-value\", jsonData.backups[0].encrypted_value);\r",
+											"pm.collectionVariables.set(\"user1-backup2-value\", jsonData.backups[1].encrypted_value);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"guardian_id\": \"e2e-ada-{{run-id}}\",\n    \"quorum\": 2,\n    \"public_keys\": [\n        {{user1-public-key-all}},\n        {{user2-public-key-all}}\n    ],\n    \"override_rsa\": true\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{guardian-url}}/api/{{version}}/guardian/backup",
+									"host": [
+										"{{guardian-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian",
+										"backup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.12 Create Guardian2 Backup",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();\r",
+											"pm.collectionVariables.set(\"user2-backups\", JSON.stringify(jsonData.backups));\r",
+											"pm.collectionVariables.set(\"user2-backup1-value\", jsonData.backups[0].encrypted_value);\r",
+											"pm.collectionVariables.set(\"user2-backup2-value\", jsonData.backups[1].encrypted_value);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"guardian_id\": \"e2e-alan-{{run-id}}\",\n    \"quorum\": 2,\n    \"public_keys\": [\n        {{user2-public-key-all}},\n        {{user1-public-key-all}}\n    ],\n    \"override_rsa\": true\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{guardian-url}}/api/{{version}}/guardian/backup",
+									"host": [
+										"{{guardian-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian",
+										"backup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.13 Share Guardian1 Backups",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key_name\": \"e2e-key_ceremony_{{run-id}}\",\n    \"guardian_id\": \"e2e-ada-{{run-id}}\",\n    \"backups\": {{user1-backups}}\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/key/guardian/backup",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"key",
+										"guardian",
+										"backup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.14 Share Guardian2 Backups",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key_name\": \"e2e-key_ceremony_{{run-id}}\",\n    \"guardian_id\": \"e2e-alan-{{run-id}}\",\n    \"backups\": {{user2-backups}}\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/key/guardian/backup",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"key",
+										"guardian",
+										"backup"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.15 Verify Guardian1 Backup (Guardian)",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"guardian_id\": \"e2e-ada-{{run-id}}\",\n    \"backup\": {\n            \"owner_id\": \"e2e-alan-{{run-id}}\",\n            \"designated_id\": \"e2e-ada-{{run-id}}\",\n            \"designated_sequence_order\": 1,\n            \"encrypted_value\": \"{{user1-backup2-value}}\"\n    },\n    \"override_rsa\": true\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{guardian-url}}/api/{{version}}/guardian/backup/verify",
+									"host": [
+										"{{guardian-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian",
+										"backup",
+										"verify"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.16 Verify Guardian2 Backup (Guardian)",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"guardian_id\": \"e2e-alan-{{run-id}}\",\n    \"backup\": {\n            \"owner_id\": \"e2e-ada-{{run-id}}\",\n            \"designated_id\": \"e2e-alan-{{run-id}}\",\n            \"designated_sequence_order\": 2,\n            \"encrypted_value\": \"{{user2-backup2-value}}\"\n    },\n    \"override_rsa\": true\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{guardian-url}}/api/{{version}}/guardian/backup/verify",
+									"host": [
+										"{{guardian-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"guardian",
+										"backup",
+										"verify"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.17 Verify Guardian1 Backups (Mediator)",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key_name\": \"e2e-key_ceremony_{{run-id}}\",\n    \"guardian_id\": \"e2e-ada-{{run-id}}\",\n    \"verifications\": [\n        {\n            \"owner_id\": \"e2e-alan-{{run-id}}\",\n            \"designated_id\": \"e2e-ada-{{run-id}}\",\n            \"verifier_id\": \"e2e-ada-{{run-id}}\",\n            \"verified\": true\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/key/guardian/verify",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"key",
+										"guardian",
+										"verify"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.18 Verify Guardian2 Backups (Mediator)",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key_name\": \"e2e-key_ceremony_{{run-id}}\",\n    \"guardian_id\": \"e2e-alan-{{run-id}}\",\n    \"verifications\": [\n        {\n            \"owner_id\": \"e2e-ada-{{run-id}}\",\n            \"designated_id\": \"e2e-alan-{{run-id}}\",\n            \"verifier_id\": \"e2e-alan-{{run-id}}\",\n            \"verified\": true\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/key/guardian/verify",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"key",
+										"guardian",
+										"verify"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "3.19 Publish Joint Key",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();\r",
+											"pm.collectionVariables.set(\"elgamal_public_key\", jsonData.elgamal_public_key);\r",
+											"pm.collectionVariables.set(\"commitment_hash\", jsonData.commitment_hash);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"election_public_keys\":[\n        \"{{user1-public-key-value}}\",\n        \"{{user2-public-key-value}}\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{mediator-url}}/api/{{version}}/key/ceremony/publish?key_name=e2e-key_ceremony_{{run-id}}",
+									"host": [
+										"{{mediator-url}}"
+									],
+									"path": [
+										"api",
+										"{{version}}",
+										"key",
+										"ceremony",
+										"publish"
+									],
+									"query": [
+										{
+											"key": "key_name",
+											"value": "e2e-key_ceremony_{{run-id}}"
+										}
 									]
 								}
 							},
@@ -301,6 +861,54 @@
 	"variable": [
 		{
 			"key": "run-id",
+			"value": ""
+		},
+		{
+			"key": "user1-public-key-value",
+			"value": ""
+		},
+		{
+			"key": "user1-public-key-all",
+			"value": ""
+		},
+		{
+			"key": "user2-public-key-value",
+			"value": ""
+		},
+		{
+			"key": "user2-public-key-all",
+			"value": ""
+		},
+		{
+			"key": "user1-backups",
+			"value": ""
+		},
+		{
+			"key": "user1-backup1-value",
+			"value": ""
+		},
+		{
+			"key": "user1-backup2-value",
+			"value": ""
+		},
+		{
+			"key": "user2-backups",
+			"value": ""
+		},
+		{
+			"key": "user2-backup1-value",
+			"value": ""
+		},
+		{
+			"key": "user2-backup2-value",
+			"value": ""
+		},
+		{
+			"key": "elgamal_public_key",
+			"value": ""
+		},
+		{
+			"key": "commitment_hash",
 			"value": ""
 		}
 	]

--- a/tests/postman/Local Environment.postman_environment.json
+++ b/tests/postman/Local Environment.postman_environment.json
@@ -25,9 +25,21 @@
 			"value": "http://localhost:8001",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "admin-username",
+			"value": "default",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "admin-password",
+			"value": "<this is a default value and should be changed>",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-03-16T14:14:18.587Z",
+	"_postman_exported_at": "2022-03-16T14:41:09.171Z",
 	"_postman_exported_using": "Postman/9.14.14"
 }

--- a/tests/postman/Local Environment.postman_environment.json
+++ b/tests/postman/Local Environment.postman_environment.json
@@ -1,0 +1,33 @@
+{
+	"id": "2885a030-5ece-44af-bb85-c8d2804e4cfd",
+	"name": "Local",
+	"values": [
+		{
+			"key": "token",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "mediator-url",
+			"value": "http://localhost:8000",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "version",
+			"value": "v1",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "guardian-url",
+			"value": "http://localhost:8001",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2022-03-16T14:14:18.587Z",
+	"_postman_exported_using": "Postman/9.14.14"
+}


### PR DESCRIPTION
### Issue

Fixes #221 

### Description
Includes all requests to complete a key ceremony and produce an elgamal public key for an election with two guardians and a quorum of two.

### Testing
1. Import the postman collection: `ElectionGuard API Tests.postman_collection.json`
2. Import the Environment: `Local Environment.postman_environment.json`
3. If you want manually run through the authenticate and login steps, then all 19 steps of the key ceremony:

![image](https://user-images.githubusercontent.com/1769905/158805428-88e69950-a5e2-43b1-852e-ba654489bd11.png)

4. Run through the tests automatically by clicking "End-To-End Happy Path" and "Run" in the top right

Expected: all tests pass and look like this:

![image](https://user-images.githubusercontent.com/1769905/158816506-008f1577-2645-4b3a-8ab6-3acacb81d148.png)

Expected: The last test 3.19 will print the name of the key ceremony